### PR TITLE
 chore(ci): Publish container images via CI/CD

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release-next-container:
+    uses: radiorabe/actions/.github/workflows/release-container.yaml@v0.37.0
+    with:
+      image: 'ghcr.io/radiorabe/website-stack/next'
+      name: 'next'
+      display-name: 'RaBe Nextjs Website'
+      tags: 'rabe web nextjs alpine'
+      # the alpine base image used for the nextjs frontend does not have a
+      # keyless cosign signature, so we disable verifying the image.
+      cosign-verify: false
+      context: './next/'
+      dockerfile: './next/Dockerfile.prod'
+      push-default-branch: true
+      build-args: |
+        IMAGES_HOSTNAME=data.rabe.ch

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,12 @@
+name: Scheduled tasks
+
+on:
+  schedule:
+    - cron:  '13 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  schedule-trivy:
+    uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.30.1
+    with:
+      image-ref: 'ghcr.io/radiorabe/website-stack/next:latest'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Next:
 
     docker-compose up -d next
 
-
 # Maintenance Mode
     In the .env file set NEXT_PUBLIC_MAINTENANCE_MODE true
 
@@ -27,3 +26,8 @@ Next:
     redirect data.rabe.ch auf rabe.ch
 
     disable healthcheck for next instance
+
+# Build Process
+
+The CI/CD setup uses [Docker build-push Action](https://github.com/docker/build-push-action) to publish container images.
+The workflow is based on the [RaBe shared actions](https://radiorabe.github.io/actions/).

--- a/next/Dockerfile.prod
+++ b/next/Dockerfile.prod
@@ -20,6 +20,12 @@ RUN \
 
 # Rebuild the source code only when needed
 FROM base AS builder
+
+# defaults for use during the container build phase on CI/CD
+ARG IMAGES_PROTOCOL=https
+ARG IMAGES_HOSTNAME=**
+ARG IMAGES_PORT=433
+
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .


### PR DESCRIPTION
Publish container images to ghcr.io based on [rabe actions](https://radiorabe.github.io/actions/#container-release).

After merge this will:
* publish each change to the main branch as `ghcr.io/radiorabe/website-stack/next:latest`
* publish tags as `ghcr.io/radiorabe/website-stack/next:<tag>`
* run a daily container image security scan on the `latest` image and upload the results to the GitHub security tab

This reflects our container image build best-practices. In this type of image build, we recommend using a pull-request based approach with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and [semantic-release](https://github.com/go-semantic-release/semantic-release) to ensure that every change is automatically tagged and released, I'll followup on this in #13.

* Fixes #11 