### PR TITLE
chore(ci): Configure eslint in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  pull_request:
+
+env:
+  IMAGES_HOSTNAME: "*"
+
+jobs:
+  next-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: next/yarn.lock
+
+      - name: Install eslint (for easier rebasing, could be added to packages.json later)
+        working-directory: ./next
+        run: yarn add --dev typescript eslint-config-next 'eslint@^9'
+
+      - name: Install dependencies
+        working-directory: ./next
+        run: yarn install --frozen-lockfile
+
+      - name: Running linter
+        working-directory: ./next
+        run: yarn run eslint --output-file ../next-eslint_report.json --format json
+        continue-on-error: true
+
+      - name: Annotate Code Linting Results
+        uses: ataylorme/eslint-annotate-action@v3
+        with:
+          report-json: "next-eslint_report.json"
+          only-pr-files: false
+        continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  pull_request:
+
+env:
+  IMAGES_HOSTNAME: "*"
+
+jobs:
+  next-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: next/yarn.lock
+
+      - name: Install eslint (for easier rebasing, could be added to packages.json later)
+        working-directory: ./next
+        run: yarn add --dev typescript eslint-config-next 'eslint@^9'
+
+      - name: Install dependencies
+        working-directory: ./next
+        run: yarn install --frozen-lockfile
+
+      - name: Running linter
+        working-directory: ./next
+        run: yarn run eslint --output-file ../next-eslint_report.json --format json
+        continue-on-error: true
+
+      - name: Annotate Code Linting Results
+        uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9 # 3.0.0
+        with:
+          report-json: "next-eslint_report.json"
+          only-pr-files: false
+        continue-on-error: true

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+  ]),
+])
+
+export default eslintConfig

--- a/next/Dockerfile.prod
+++ b/next/Dockerfile.prod
@@ -20,6 +20,7 @@ RUN \
 
 # Rebuild the source code only when needed
 FROM base AS builder
+
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/next/package.json
+++ b/next/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "lint": "next lint",
     "build": "next build",
     "start": "node .next/standalone/server.js",
     "syncDataModel": "node bin/syncDataModel.js",

--- a/next/package.json
+++ b/next/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "lint": "next lint",
     "build": "next build --webpack",
     "start": "node .next/standalone/server.js",
     "syncDataModel": "node bin/syncDataModel.js",


### PR DESCRIPTION
Configure [eslint](https://eslint.org/) to run against the code. Based on the [Next.JS reference configuration](https://nextjs.org/docs/app/api-reference/config/eslint). `eslint` does static testing, it's raison d'être is to ensure that the quality of code matches what can be reasonably expected from a modern next application. This improves the security, readability, and maintainability of the code.

Since the `next/` folder was initialized with typescript support, we configure eslint for typescript.

**note:** A high amount of eslint complaints is expected when initially adopting eslint. Most likely they consist of a ton of low hanging fruit that can be easily auto-fixed.

* fixes #12  